### PR TITLE
Add source URL, py3 classifier to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
     packages=['gam', 'tests'],
     maintainer='Brian Barr',
     maintainer_email='brian.barr@capitalone.com',
+    url="https://github.com/capitalone/global-attribution-mapping",
+    classifiers=["Programming Language :: Python :: 3"],
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Without a `url` in `setup` there is no path back from https://pypi.org/project/gam/

Also a good policy to list out supported major versions of Python.  I don't know if you have any hard requirements (maybe this project uses f-strings?), in which case you'll want to add a `python_requires >= 3.6`, too