### PR TITLE
adding ability to pass in dataframe or array

### DIFF
--- a/gam/gam.py
+++ b/gam/gam.py
@@ -98,8 +98,8 @@ class GAM:
             feature labels: ("height", "weight")
         """
         if isinstance(self.attributions, pd.DataFrame):
-            self.attributions = np.asarray(self.attributions.values.tolist())
             self.feature_labels = self.attributions.columns.tolist()
+            self.attributions = np.asarray(self.attributions.values.tolist())
         elif isinstance(self.attributions, (np.ndarray, list)) or isinstance(self.feature_labels, (np.ndarray, list)):
             if (isinstance(self.attributions, (np.ndarray, list)) and self.feature_labels is None) or (self.attributions is None and self.feature_labels is not None):
                 raise ValueError("You must have both 'attributions' and 'feature_labels' if 'attributions' is not a dataframe.")
@@ -112,6 +112,7 @@ class GAM:
             elif isinstance(self.feature_labels, np.ndarray):
                 self.feature_labels = self.feature_labels.tolist()
         else:
+            print('should not be here')
             self.attributions = None
             self.feature_labels = None
 
@@ -234,11 +235,11 @@ class GAM:
 
     def generate(self):
         """Clusters local attributions into subpopulations with global explanations"""
-        if isinstance(self.attributions, str):
+        if self.attributions is not None:
+            self._read_df_or_list()
+        else:
             # we need to read in attributions from a CSV file, since we don't have any in memory
             self._read_local()
-        else:
-            self._read_df_or_list()
         if self.use_normalized:
             self.clustering_attributions = GAM.normalize(self.attributions)
         else:

--- a/gam/gam.py
+++ b/gam/gam.py
@@ -59,24 +59,8 @@ class GAM:
 
         self.attributions_path = attributions_path
 
-        # preprocessing attributions and feature_labels if they're a pandas dataframe, numpy array, or list
-        if isinstance(attributions, pd.DataFrame):
-            self.attributions = np.asarray(attributions.values.tolist())
-            self.feature_labels = attributions.columns.tolist()
-        elif isinstance(attributions, (np.ndarray, list)) or isinstance(feature_labels, (np.ndarray, list)):
-            if (isinstance(attributions, (np.ndarray, list)) and feature_labels is None) or (attributions is None and feature_labels is not None):
-                raise ValueError("You must have both 'attributions' and 'feature_labels' if 'attributions' is not a dataframe.")
-            if isinstance(attributions, list):
-                self.attributions = np.asarray(attributions)
-            elif isinstance(attributions, np.ndarray):
-                self.attributions = attributions
-            if isinstance(feature_labels, list):
-                self.feature_labels = feature_labels
-            elif isinstance(feature_labels, np.ndarray):
-                self.feature_labels = feature_labels.tolist()
-        else:
-            self.attributions=None
-            self.feature_labels = None
+        self.attributions = attributions
+        self.feature_labels = feature_labels
 
         # self.normalized_attributions = None
         self.use_normalized = use_normalized
@@ -104,6 +88,32 @@ class GAM:
 
         self.scoring_method = scoring_method
         self.score = None
+
+    def _read_df_or_list(self):
+        """
+        Converts attributions to numpy array and feature labels to a list if a pandas dataframe, numpy array, or list is passed in,
+
+        Returns
+            attributions (numpy.ndarray): for example, [(.2, .8), (.1, .9)]
+            feature labels: ("height", "weight")
+        """
+        if isinstance(self.attributions, pd.DataFrame):
+            self.attributions = np.asarray(self.attributions.values.tolist())
+            self.feature_labels = self.attributions.columns.tolist()
+        elif isinstance(self.attributions, (np.ndarray, list)) or isinstance(self.feature_labels, (np.ndarray, list)):
+            if (isinstance(self.attributions, (np.ndarray, list)) and self.feature_labels is None) or (self.attributions is None and self.feature_labels is not None):
+                raise ValueError("You must have both 'attributions' and 'feature_labels' if 'attributions' is not a dataframe.")
+            if isinstance(self.attributions, list):
+                self.attributions = np.asarray(self.attributions)
+            elif isinstance(self.attributions, np.ndarray):
+                self.attributions = self.attributions
+            if isinstance(self.feature_labels, list):
+                self.feature_labels = self.feature_labels
+            elif isinstance(self.feature_labels, np.ndarray):
+                self.feature_labels = self.feature_labels.tolist()
+        else:
+            self.attributions = None
+            self.feature_labels = None
 
     def _read_local(self):
         """
@@ -227,6 +237,8 @@ class GAM:
         if self.attributions is None:
             # we need to read in attributions from a CSV file, since we don't have any in memory
             self._read_local()
+        else:
+            self._read_df_or_list()
         if self.use_normalized:
             self.clustering_attributions = GAM.normalize(self.attributions)
         else:

--- a/gam/gam.py
+++ b/gam/gam.py
@@ -234,7 +234,7 @@ class GAM:
 
     def generate(self):
         """Clusters local attributions into subpopulations with global explanations"""
-        if self.attributions is None:
+        if isinstance(self.attributions, str):
             # we need to read in attributions from a CSV file, since we don't have any in memory
             self._read_local()
         else:

--- a/gam/gam.py
+++ b/gam/gam.py
@@ -13,6 +13,7 @@ from collections import Counter
 
 import matplotlib.pylab as plt
 import numpy as np
+import pandas as pd
 from sklearn.metrics import pairwise_distances, silhouette_score
 
 from gam.clustering import KMedoids
@@ -30,6 +31,8 @@ class GAM:
     Args:
         k (int): number of clusters and centroids to form, default=2
         attributions_path (str): path for csv containing local attributions
+        attributions_df (pd.DataFrame, np.array, list): in-memory dataframe holding local attributions
+        feature_labels
         cluster_method: None, or callable, default=None
             None - use GAM library routines for k-medoids clustering
             callable - user provided external function to perform clustering
@@ -44,6 +47,8 @@ class GAM:
         self,
         k=2,
         attributions_path="local_attributions.csv",
+        attributions=None,
+        feature_labels=None,
         cluster_method=None,
         distance="spearman",
         use_normalized=True,
@@ -51,7 +56,32 @@ class GAM:
         max_iter=100,
         tol=1e-3,
     ):
+
         self.attributions_path = attributions_path
+
+        # preprocessing attributions and feature_labels if they're a pandas dataframe, numpy array, or list
+        if isinstance(attributions, pd.DataFrame):
+            self.attributions = np.asarray(attributions.values.tolist())
+            self.feature_labels = attributions.columns.tolist()
+        elif isinstance(attributions, (np.ndarray, list)) or isinstance(feature_labels, (np.ndarray, list)):
+            if (isinstance(attributions, (np.ndarray, list)) and feature_labels is None) or (attributions is None and feature_labels is not None):
+                raise ValueError("You must have both 'attributions' and 'feature_labels' if 'attributions' is not a dataframe.")
+            if isinstance(attributions, list):
+                self.attributions = np.asarray(attributions)
+            elif isinstance(attributions, np.ndarray):
+                self.attributions = attributions
+            if isinstance(feature_labels, list):
+                self.feature_labels = feature_labels
+            elif isinstance(feature_labels, np.ndarray):
+                self.feature_labels = feature_labels.tolist()
+        else:
+            self.attributions=None
+            self.feature_labels = None
+
+        # self.normalized_attributions = None
+        self.use_normalized = use_normalized
+        self.clustering_attributions = None
+
         self.cluster_method = cluster_method
 
         self.distance = distance
@@ -64,21 +94,15 @@ class GAM:
                 distance
             )  # assume this is  metric listed in pairwise.PAIRWISE_DISTANCE_FUNCTIONS
 
-        self.scoring_method = scoring_method
-
         self.k = k
         self.max_iter = max_iter
         self.tol = tol
 
-        self.attributions = None
-        # self.normalized_attributions = None
-        self.use_normalized = use_normalized
-        self.clustering_attributions = None
-        self.feature_labels = None
-
         self.subpopulations = None
         self.subpopulation_sizes = None
         self.explanations = None
+
+        self.scoring_method = scoring_method
         self.score = None
 
     def _read_local(self):
@@ -200,7 +224,9 @@ class GAM:
 
     def generate(self):
         """Clusters local attributions into subpopulations with global explanations"""
-        self._read_local()
+        if self.attributions is None:
+            # we need to read in attributions from a CSV file, since we don't have any in memory
+            self._read_local()
         if self.use_normalized:
             self.clustering_attributions = GAM.normalize(self.attributions)
         else:

--- a/tests/test_gam.py
+++ b/tests/test_gam.py
@@ -7,6 +7,7 @@ import glob
 import os
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from gam import gam

--- a/tests/test_gam.py
+++ b/tests/test_gam.py
@@ -16,14 +16,15 @@ from gam import gam
 def test_read_df_or_list():
     # preprocessing
     df = pd.read_csv("tests/test_attributes.csv")
-    att_list = df.columns.tolist()
-    feat_labels_list = df.values.tolist()
+    att_list = df.values.tolist()
+    feat_labels_list = df.columns.tolist()
 
-    att_arr = np.asarray(df.columns.tolist())
-    feat_labels_arr = np.asarray(df.values.tolist())
+    att_arr = np.asarray(df.values.tolist())
+    feat_labels_arr = np.asarray(df.columns.tolist())
 
     # Testing DataFrame
     g_df = gam.GAM(attributions=df)
+    g_df.generate()
 
     assert hasattr(g_df, "attributions")
     assert g_df.attributions.shape == (4, 3)
@@ -33,6 +34,7 @@ def test_read_df_or_list():
 
     # Testing lists
     g_list = gam.GAM(attributions=att_list, feature_labels=feat_labels_list)
+    g_list.generate()
 
     assert hasattr(g_list, "attributions")
     assert g_list.attributions.shape == (4, 3)
@@ -42,6 +44,7 @@ def test_read_df_or_list():
     
     # Testing numpy arrays
     g_arr = gam.GAM(attributions=att_arr, feature_labels=feat_labels_arr)
+    g_arr.generate()
 
     assert hasattr(g_arr, "attributions")
     assert g_arr.attributions.shape == (4, 3)
@@ -52,6 +55,7 @@ def test_read_df_or_list():
     # Testing failure
     with pytest.raises(ValueError):
         g_fail = gam.GAM(attributions=att_arr)
+        g_fail.generate()
 
 
 def test_read_csv():

--- a/tests/test_gam.py
+++ b/tests/test_gam.py
@@ -12,6 +12,47 @@ import pytest
 from gam import gam
 
 
+def test_read_df_or_list():
+    # preprocessing
+    df = pd.read_csv("tests/test_attributes.csv")
+    att_list = df.columns.tolist()
+    feat_labels_list = df.values.tolist()
+
+    att_arr = np.asarray(df.columns.tolist())
+    feat_labels_arr = np.asarray(df.values.tolist())
+
+    # Testing DataFrame
+    g_df = gam.GAM(attributions=df)
+
+    assert hasattr(g_df, "attributions")
+    assert g_df.attributions.shape == (4, 3)
+
+    assert hasattr(g_df, "feature_labels")
+    assert g_df.feature_labels == ["a1", "a2", "a3"]
+
+    # Testing lists
+    g_list = gam.GAM(attributions=att_list, feature_labels=feat_labels_list)
+
+    assert hasattr(g_list, "attributions")
+    assert g_list.attributions.shape == (4, 3)
+
+    assert hasattr(g_list, "feature_labels")
+    assert g_list.feature_labels == ["a1", "a2", "a3"]
+    
+    # Testing numpy arrays
+    g_arr = gam.GAM(attributions=att_arr, feature_labels=feat_labels_arr)
+
+    assert hasattr(g_arr, "attributions")
+    assert g_arr.attributions.shape == (4, 3)
+
+    assert hasattr(g_arr, "feature_labels")
+    assert g_arr.feature_labels == ["a1", "a2", "a3"]
+    
+    # Testing failure
+    with pytest.raises(ValueError):
+        g_fail = gam.GAM(attributions=att_arr)
+
+
 def test_read_csv():
     g = gam.GAM(attributions_path="tests/test_attributes.csv")
     g._read_local()


### PR DESCRIPTION
The goal of this PR is to allow a user to pass in a dataframe, list, or numpy array to the constructor and have the same functionality that it would if you were to pass in a path to a dataframe. This can be useful for many users if they like to do some sort of preprocessing on the dataframe, or have their model running in a notebook so that they can just pass in the dataframe or array directly to the GAM constructor.

This is what the code would look like if you want to pass in a dataframe:
```
df = pd.read_csv('test.csv')
g = gam.GAM(attributions=df)
```

This is what the code would look like if you want to pass in an array
```
att_arr = np.array([[1, 2, 3][4, 5, 6][7, 8, 9]])
feat_labels_arr = np.array(['col1', 'col2', 'col3'])
g = gam.GAM(attributions=att_arr, feature_labels=feat_labels_arr)
```