### PR TITLE
Resolving CVE-2021-42343

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 atomicwrites==1.1.5
 attrs==19.2.0
-dask[complete]==2021.2.0
+dask[complete]==2021.12.0
 dask-distance==0.2.0
 dask-ml==1.8.0
 kaleido==0.2.1


### PR DESCRIPTION
Resolving CVE-2021-42343 (High) detected in dask-2021.2.0-py3-none-any.whl by updating dask to 2021-12-0

Resolves #59 